### PR TITLE
Allow setting default ParseEnv, ParseBacktick

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ args, err := p.Parse("./foo `echo $SHELL`")
 // args should be ["./foo", "/bin/bash"]
 ```
 
+```go
+shellwords.ParseBacktick = true
+p := shellwords.NewParser()
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
 # Thanks
 
 This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).

--- a/shellwords.go
+++ b/shellwords.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 )
 
+var (
+	ParseEnv      bool = false
+	ParseBacktick bool = false
+)
+
 var envRe = regexp.MustCompile(`\$({[a-zA-Z0-9_]+}|[a-zA-Z0-9_]+)`)
 
 func isSpace(r rune) bool {
@@ -33,7 +38,7 @@ type Parser struct {
 }
 
 func NewParser() *Parser {
-	return new(Parser)
+	return &Parser{ParseEnv, ParseBacktick}
 }
 
 func (p *Parser) Parse(line string) ([]string, error) {


### PR DESCRIPTION
As per commit message, this allows changing the default `ParseEnv` and `ParseBacktick`. Handy if you're using it only in one or two place in your project and don't want to hold to a global instance or reset the config each time using `shellwords.Parse`.
