### PR TITLE
Return process Stderr in shellRun error

### DIFF
--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -92,6 +92,10 @@ func TestBacktickError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Should be an error")
 	}
+	expected := "exit status 2:go: unknown subcommand \"Version\"\nRun 'go help' for usage.\n"
+	if expected != err.Error() {
+		t.Fatalf("Expected %q, but %q", expected, err.Error())
+	}
 }
 
 func TestEnv(t *testing.T) {

--- a/util_posix.go
+++ b/util_posix.go
@@ -13,6 +13,9 @@ func shellRun(line string) (string, error) {
 	shell := os.Getenv("SHELL")
 	b, err := exec.Command(shell, "-c", line).Output()
 	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
 		return "", errors.New(err.Error() + ":" + string(b))
 	}
 	return strings.TrimSpace(string(b)), nil

--- a/util_windows.go
+++ b/util_windows.go
@@ -11,6 +11,9 @@ func shellRun(line string) (string, error) {
 	shell := os.Getenv("COMSPEC")
 	b, err := exec.Command(shell, "/c", line).Output()
 	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
 		return "", errors.New(err.Error() + ":" + string(b))
 	}
 	return strings.TrimSpace(string(b)), nil


### PR DESCRIPTION
[`exec.Cmd.Output`](https://golang.org/pkg/os/exec/#Cmd.Output) returns only the Stdout of the executed process, thus the actual error message was being lost. In cases where the subprocess
return a [`exec.ExitError`](https://golang.org/pkg/os/exec/#ExitError) use `exec.ExitError.Stderr` as the ouput.

It should've been possible to use [`exec.Cmd.CombinedOutput`](https://golang.org/pkg/os/exec/#Cmd.CombinedOutput) that returns both Stdout and Stderr in an unified way, but with this a successful command that also returns something in Stderr will interpolate Stderr in the returned string.