### PR TITLE
Enable go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/mattn/go-shellwords


### PR DESCRIPTION
Similar to https://github.com/mattn/go-isatty/pull/28

----

This is a result of the following commands:

```
go mod init
go get ./...
go mod tidy
```

in a clean Go `1.11.5` environment.