### PR TITLE
Support empty arguments

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -144,11 +144,17 @@ loop:
 			}
 		case '"':
 			if !singleQuoted && !dollarQuote {
+				if doubleQuoted && buf == "" {
+					got = true
+				}
 				doubleQuoted = !doubleQuoted
 				continue
 			}
 		case '\'':
 			if !doubleQuoted && !dollarQuote {
+				if singleQuoted && buf == "" {
+					got = true
+				}
 				singleQuoted = !singleQuoted
 				continue
 			}

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -69,6 +69,28 @@ func TestLastSpace(t *testing.T) {
 	}
 }
 
+func TestEmptyArgs(t *testing.T) {
+	args, err := Parse(`foo "" bar ''`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != 4 {
+		t.Fatal("Should have three elements")
+	}
+	if args[0] != "foo" {
+		t.Fatal("1st element should be `foo`")
+	}
+	if args[1] != "" {
+		t.Fatal("2nd element should be empty")
+	}
+	if args[2] != "bar" {
+		t.Fatal("3rd element should be `bar`")
+	}
+	if args[3] != "" {
+		t.Fatal("4th element should be empty")
+	}
+}
+
 func TestShellRun(t *testing.T) {
 	dir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Currently

```
Parse(`foo "" bar ''`)
```
ignores the empty parameters and gives `["foo","bar"]`.  This should not be the case since a shell will detect these empty arguments.  Furthermore, according to #5 the current behaviour is not correct.

With this PR the `Parse` result becomes `["foo", "", "bar", ""]` as described in #5 and as a shell would have interpreted. 