### PR TITLE
Support arguments consisting only of escaped string

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -70,6 +70,7 @@ loop:
 		if escaped {
 			buf += string(r)
 			escaped = false
+			got = true
 			continue
 		}
 

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -34,6 +34,8 @@ var testcases = []struct {
 	{`a '   '`, []string{`a`, `   `}},
 	{"foo bar\\  ", []string{`foo`, `bar `}},
 	{`foo "" bar ''`, []string{`foo`, ``, `bar`, ``}},
+	{`foo \\`, []string{`foo`, `\`}},
+	{`foo \& bar`, []string{`foo`, `&`, `bar`}},
 }
 
 func TestSimple(t *testing.T) {


### PR DESCRIPTION
Currently, arguments consisting only of escaped characters are merged with the following arguments.

This pull request fixes the issue. Also adds some tests.

## Reproducible example

```go
Parse(`foo \& bar`)
```

## Expected result

```go
[]string{"foo", "&", "bar"}
```

## Actual result

```go
[]string{"foo", "&bar"}
```


