### PR TITLE
Fix confusion between bytes and runes in example code

### DIFF
--- a/_example/pipe.go
+++ b/_example/pipe.go
@@ -38,7 +38,7 @@ func main() {
 				break
 			}
 		}
-		fmt.Println(string([]rune(line)[parser.Position:i]))
-		line = string([]rune(line)[i+1:])
+		fmt.Println(line[parser.Position:i])
+		line = line[i+1:]
 	}
 }


### PR DESCRIPTION
`_example/pipe.go` has an unnecessary cast from string to runes.

Of course, as long as we never parse the multibyte string, there's no problem. However, if we change the value of `line` to `/usr/bin/ls -la あ* | sort 2>&1 | tee files.log`, we get strange results as follows:

```
[/usr/bin/ls -la あ*]
s
[rt]
2>&1
[]
|
[tee files.log]
```

