### PR TITLE
Fix to return rune-based position for parser.Position

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -65,8 +65,10 @@ func (p *Parser) Parse(line string) ([]string, error) {
 	pos := -1
 	got := false
 
+	i := -1
 loop:
-	for i, r := range line {
+	for _, r := range line {
+		i++
 		if escaped {
 			buf += string(r)
 			escaped = false

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -321,12 +321,12 @@ func TestHaveMore(t *testing.T) {
 	parser := NewParser()
 	parser.ParseEnv = true
 
-	line := "echo foo; seq 1 10"
+	line := "echo 🍺; seq 1 10"
 	args, err := parser.Parse(line)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	expected := []string{"echo", "foo"}
+	expected := []string{"echo", "🍺"}
 	if !reflect.DeepEqual(args, expected) {
 		t.Fatalf("Expected %#v, but %#v:", expected, args)
 	}


### PR DESCRIPTION
Currently `parser.Position` returns byte-based position. However, this is unexpected behavior.

This pull request fixes the behavior to rune-based.

See the discussion in #42 for details.