### PR TITLE
Add a new function to parse a line containing environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ args, err := shellwords.Parse("./foo --bar=baz")
 ```
 
 ```go
+envs, args, err := shellwords.ParseWithEnvs("FOO=foo BAR=baz ./foo --bar=baz")
+// envs should be ["FOO=foo", "BAR=baz"]
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
 os.Setenv("FOO", "bar")
 p := shellwords.NewParser()
 p.ParseEnv = true

--- a/shellwords.go
+++ b/shellwords.go
@@ -290,6 +290,35 @@ loop:
 	return args, nil
 }
 
+func (p *Parser) ParseWithEnvs(line string) (envs []string, args []string, err error) {
+	_args, err := p.Parse(line)
+	if err != nil {
+		return nil, nil, err
+	}
+	envs = []string{}
+	args = []string{}
+	parsingEnv := true
+	for _, arg := range _args {
+		if parsingEnv && isEnv(arg) {
+			envs = append(envs, arg)
+		} else {
+			if parsingEnv {
+				parsingEnv = false
+			}
+			args = append(args, arg)
+		}
+	}
+	return envs, args, nil
+}
+
+func isEnv(arg string) bool {
+	return len(strings.Split(arg, "=")) == 2
+}
+
 func Parse(line string) ([]string, error) {
 	return NewParser().Parse(line)
+}
+
+func ParseWithEnvs(line string) (envs []string, args []string, err error) {
+	return NewParser().ParseWithEnvs(line)
 }

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -407,3 +407,45 @@ func TestEnvInQuoted(t *testing.T) {
 		t.Fatalf("Expected %#v, but %#v:", expected, args)
 	}
 }
+
+func TestParseWithEnvs(t *testing.T) {
+	tests := []struct {
+		line               string
+		wantEnvs, wantArgs []string
+	}{
+		{
+			line:     "FOO=foo cmd --args=A=B",
+			wantEnvs: []string{"FOO=foo"},
+			wantArgs: []string{"cmd", "--args=A=B"},
+		},
+		{
+			line:     "FOO=foo BAR=bar cmd --args=A=B -A=B",
+			wantEnvs: []string{"FOO=foo", "BAR=bar"},
+			wantArgs: []string{"cmd", "--args=A=B", "-A=B"},
+		},
+		{
+			line:     `sh -c "FOO=foo BAR=bar cmd --args=A=B -A=B"`,
+			wantEnvs: []string{},
+			wantArgs: []string{"sh", "-c", "FOO=foo BAR=bar cmd --args=A=B -A=B"},
+		},
+		{
+			line:     "cmd --args=A=B -A=B",
+			wantEnvs: []string{},
+			wantArgs: []string{"cmd", "--args=A=B", "-A=B"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			envs, args, err := ParseWithEnvs(tt.line)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(envs, tt.wantEnvs) {
+				t.Errorf("Expected %#v, but %#v", tt.wantEnvs, envs)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("Expected %#v, but %#v", tt.wantArgs, args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a new function because there are relatively many use cases to parse a line that contains environment variables.

If you don't like this Pull Request, just ignore.

I think the name `ParseWithEnvs` is inappropriate. I'm looking for a good name.