### PR TITLE
fix trying to parse subshell calls as env vars

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -43,7 +43,12 @@ func replaceEnv(getenv func(string) string, s string) string {
 				buf.WriteRune(r)
 				break
 			}
-			if rs[i] == 0x7b {
+			if rs[i] == '(' { // subshell call, not env variable
+				buf.WriteRune(rs[i-1])
+				buf.WriteRune(rs[i])
+				continue
+			}
+			if rs[i] == 0x7b { // '{', bracketed shell variable
 				i++
 				p := i
 				for ; i < len(rs); i++ {

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -503,4 +503,44 @@ func TestSubShellEnv(t *testing.T) {
 			t.Fatalf(errTmpl, expected, args)
 		}
 	})
+
+	t.Run("single-quoted-subshell-call", func(t *testing.T) {
+		args, err := myParser.Parse(`sh -c 'echo $(foo)'`)
+		if err != nil {
+			t.Fatalf("err should be nil: %v", err)
+		}
+		expected := []string{"sh", "-c", "echo $(foo)"}
+		if len(args) != 3 {
+			t.Fatalf(errTmpl, expected, args)
+		}
+		if args[0] != expected[0] || args[1] != expected[1] || args[2] != expected[2] {
+			t.Fatalf(errTmpl, expected, args)
+		}
+	})
+	t.Run("double-quoted-subshell-call", func(t *testing.T) {
+		args, err := myParser.Parse(`sh -c "echo $(foo)"`)
+		if err != nil {
+			t.Fatalf("err should be nil: %v", err)
+		}
+		expected := []string{"sh", "-c", "echo $(foo)"}
+		if len(args) != 3 {
+			t.Fatalf(errTmpl, expected, args)
+		}
+		if args[0] != expected[0] || args[1] != expected[1] || args[2] != expected[2] {
+			t.Fatalf(errTmpl, expected, args)
+		}
+	})
+	t.Run("subshell-call-call", func(t *testing.T) {
+		args, err := myParser.Parse(`sh -c "echo $(foo $(bar))"`)
+		if err != nil {
+			t.Fatalf("err should be nil: %v", err)
+		}
+		expected := []string{"sh", "-c", "echo $(foo $(bar))"}
+		if len(args) != 3 {
+			t.Fatalf(errTmpl, expected, args)
+		}
+		if args[0] != expected[0] || args[1] != expected[1] || args[2] != expected[2] {
+			t.Fatalf(errTmpl, expected, args)
+		}
+	})
 }


### PR DESCRIPTION
Parser didn't detect subshell calls, $(), and tried to parse them as environment variables. This picks up the $( pattern and continues on with parsing, leaving it as is.

Added tests for it as well.


