### PR TITLE
parse `\t` as TAB, not escaped `t`

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -136,6 +136,12 @@ loop:
 	for _, r := range line {
 		i++
 		if escaped {
+			if r == 't' {
+				r = '\t'
+			}
+			if r == 'n' {
+				r = '\n'
+			}
 			buf += string(r)
 			escaped = false
 			got = argSingle

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -38,6 +38,7 @@ var testcases = []struct {
 	{`foo "" bar ''`, []string{`foo`, ``, `bar`, ``}},
 	{`foo \\`, []string{`foo`, `\`}},
 	{`foo \& bar`, []string{`foo`, `&`, `bar`}},
+	{`sh -c "printf 'Hello\tworld\n'"`, []string{`sh`, `-c`, "printf 'Hello\tworld\n'"}},
 }
 
 func TestSimple(t *testing.T) {


### PR DESCRIPTION
`\t` or `\n` must be parsed as special characters TAB and NEWLINE, not considered escaped

closes https://github.com/mattn/go-shellwords/issues/52
reported by https://github.com/docker/compose/issues/8605