### PR TITLE
Add the ability to exclude specific separators from the parsing algor…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ args, err := p.Parse("./foo `echo $SHELL`")
 // args should be ["./foo", "/bin/bash"]
 ```
 
+```go
+p := shellwords.NewParser()
+p.SetExcludeSeparators('\t',';')
+```
+
 # Thanks
 
 This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).


### PR DESCRIPTION
I have implemented a way for users to exclude specific separators from the parsing algorithm to make this package more versatile and flexible. Logic is based on storing excluded characters in a slice. While parsing the command if excluded characters appear they will be ignored. I have provided GET and SET methods for the excluded character's slice for easier interaction.

The changes include adding the following features:

    - excludedSep field in the Parser struct to hold a list of separator characters to be ignored during parsing.
    - SetExcludeSeparators and ExcludedSeparators methods in the Parser struct to respectively set and get the excluded separators.
    - isExcluded method in the Parser struct to check if a separator should be ignored.

These changes enable the parser to handle cases where certain separators should be ignored during parsing.

Thank you for considering my contribution. Please let me know if there are any issues or concerns.