### PR TITLE
Add ParseComment option to trim comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ args, err := p.Parse("./foo `echo $SHELL`")
 // args should be ["./foo", "/bin/bash"]
 ```
 
+```go
+p := shellwords.NewParser()
+p.ParseComment = true
+args, err := p.Parse("./foo # comment")
+// args should be ["./foo"]
+```
+
 # Thanks
 
 This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).


### PR DESCRIPTION
This patch adds `ParseComment` option that tells the parser to trim line comments.

* `foo # bar` -> `[foo]` instead of `[foo, #, bar]`

[fzf](https://github.com/junegunn/fzf) uses this library to parse multi-line options in an environment variable or a file, and I'd like to allow comments using this option. See https://github.com/junegunn/fzf/issues/3961.

But it's totally understandable if you don't want to accept the patch. Thank you.

