### PR TITLE
Fix env var name extraction for multibyte input

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -63,7 +63,7 @@ func replaceEnv(getenv func(string) string, s string) string {
 					return s
 				}
 				if i > p {
-					buf.WriteString(getenv(s[p:i]))
+					buf.WriteString(getenv(string(rs[p:i])))
 				}
 			} else {
 				p := i
@@ -81,10 +81,10 @@ func replaceEnv(getenv func(string) string, s string) string {
 					}
 				}
 				if i > p {
-					buf.WriteString(getenv(s[p:i]))
+					buf.WriteString(getenv(string(rs[p:i])))
 					i--
 				} else {
-					buf.WriteString(s[p:])
+					buf.WriteString(string(rs[p:]))
 				}
 			}
 		} else {

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -248,6 +248,20 @@ func TestCustomEnv(t *testing.T) {
 	}
 }
 
+func TestEnvMultibyte(t *testing.T) {
+	parser := NewParser()
+	parser.ParseEnv = true
+	parser.Getenv = func(k string) string { return map[string]string{"FOO": "bar"}[k] }
+	args, err := parser.Parse("echo あい$FOO ${FOO}う")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "あいbar", "barう"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
 func TestNoEnv(t *testing.T) {
 	parser := NewParser()
 	parser.ParseEnv = true


### PR DESCRIPTION
replaceEnv sliced the original string with rune indices, so variable names were extracted incorrectly when the input contained multibyte characters (e.g. `echo あい$FOO` looked up `getenv("い")`). Slice the rune slice instead.