### PR TITLE
Fix duplicated output when $ precedes a non-variable character

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -84,7 +84,8 @@ func replaceEnv(getenv func(string) string, s string) string {
 					buf.WriteString(getenv(string(rs[p:i])))
 					i--
 				} else {
-					buf.WriteString(string(rs[p:]))
+					buf.WriteRune('$')
+					i--
 				}
 			}
 		} else {

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -262,6 +262,20 @@ func TestEnvMultibyte(t *testing.T) {
 	}
 }
 
+func TestEnvBareDollar(t *testing.T) {
+	parser := NewParser()
+	parser.ParseEnv = true
+	parser.Getenv = func(k string) string { return map[string]string{"FOO": "bar"}[k] }
+	args, err := parser.Parse("echo $@x $FOO")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "$@x", "bar"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
 func TestNoEnv(t *testing.T) {
 	parser := NewParser()
 	parser.ParseEnv = true


### PR DESCRIPTION
With ParseEnv enabled, a `$` followed by a character that cannot start a variable name wrote the rest of the string and then continued the loop over the same characters, duplicating them and dropping the `$` (e.g. `$@x` became `@xx`). Emit the `$` literally and reprocess the following character instead.