### PR TITLE
Preserve quotes inside backtick command substitution

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -256,7 +256,7 @@ loop:
 			}
 
 		case '"':
-			if !singleQuoted && !dollarQuote {
+			if !singleQuoted && !dollarQuote && !backQuote {
 				if doubleQuoted {
 					got = argQuoted
 				}
@@ -265,7 +265,7 @@ loop:
 			}
 
 		case '\'':
-			if !doubleQuoted && !dollarQuote {
+			if !doubleQuoted && !dollarQuote && !backQuote {
 				if singleQuoted {
 					got = argQuoted
 				}

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -164,6 +165,41 @@ func TestBacktick(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected = []string{"echo", "$(`echo1)"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
+func TestBacktickQuoted(t *testing.T) {
+	parser := NewParser()
+
+	args, err := parser.Parse("echo `echo \"foo  bar\"`")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "`echo \"foo  bar\"`"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("cmd.exe does not strip quotes")
+	}
+
+	parser.ParseBacktick = true
+	args, err = parser.Parse("echo `echo \"foo  bar\"`")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = []string{"echo", "foo  bar"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+
+	args, err = parser.Parse("echo `echo 'foo  bar'`")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(args, expected) {
 		t.Fatalf("Expected %#v, but %#v:", expected, args)
 	}


### PR DESCRIPTION
Single and double quotes inside `...` toggled the outer parser's quoting state and were dropped, so the quoted text was passed to the shell unquoted (`echo "a  b"` inside backticks ran as `echo a  b`). Treat quotes as literal characters while collecting a backtick command, matching how $(...) already behaves.