### PR TITLE
Do not record quoted spaces in backtick buffer outside substitution

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -161,7 +161,9 @@ loop:
 		if isSpace(r) {
 			if singleQuoted || doubleQuoted || backQuote || dollarQuote {
 				buf += string(r)
-				backtick += string(r)
+				if backQuote || dollarQuote {
+					backtick += string(r)
+				}
 			} else if got != argNo {
 				if p.ParseEnv {
 					if got == argSingle {

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -205,6 +205,29 @@ func TestBacktickQuoted(t *testing.T) {
 	}
 }
 
+func TestBacktickAfterQuoted(t *testing.T) {
+	parser := NewParser()
+	parser.ParseBacktick = true
+
+	args, err := parser.Parse(`echo "a b" c$(echo x)d`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "a b", "cxd"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+
+	args, err = parser.Parse(`echo "a b" $(echo x)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = []string{"echo", "a b", "x"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
 func TestBacktickMulti(t *testing.T) {
 	parser := NewParser()
 	parser.ParseBacktick = true


### PR DESCRIPTION
Spaces inside single/double quotes were appended to the backtick buffer even when no command substitution was open. The stale content shifted the buffer truncation when a later $(...) closed, eating characters (`echo "a b" c$(echo x)` returned `x` instead of `cx`) or failing outright (`echo "a b" $(pwd)` returned an error). Only record spaces while inside `...` or $(...).