### PR TITLE
Pass backslash escapes through to command substitution

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -137,6 +137,13 @@ loop:
 	for _, r := range line {
 		i++
 		if escaped {
+			escaped = false
+			if backQuote || dollarQuote {
+				buf += "\\" + string(r)
+				backtick += "\\" + string(r)
+				got = argSingle
+				continue
+			}
 			if r == 't' {
 				r = '\t'
 			}
@@ -144,7 +151,6 @@ loop:
 				r = '\n'
 			}
 			buf += string(r)
-			escaped = false
 			got = argSingle
 			continue
 		}

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -228,6 +228,32 @@ func TestBacktickAfterQuoted(t *testing.T) {
 	}
 }
 
+func TestSubstitutionEscaped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cmd.exe does not interpret backslash escapes")
+	}
+	parser := NewParser()
+	parser.ParseBacktick = true
+
+	args, err := parser.Parse(`echo $(echo a\ b)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "a b"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+
+	args, err = parser.Parse("echo `echo a\\  b`")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = []string{"echo", "a  b"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
 func TestBacktickMulti(t *testing.T) {
 	parser := NewParser()
 	parser.ParseBacktick = true


### PR DESCRIPTION
Escaped characters inside `...` or $(...) were unescaped by the outer parser and never recorded in the backtick buffer, so the buffer length no longer matched the collected command and the truncation on close left garbage in the output (`echo $(echo a\\ b)` returned `$a b`). Keep the backslash and the following character verbatim while collecting a substitution command so the subshell interprets them.