### PR TITLE
Fix fd redirect detection for non-numeric and multi-digit tokens

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -284,8 +284,15 @@ loop:
 		case ';', '&', '|', '<', '>':
 			if !(escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote) {
 				if r == '>' && len(buf) > 0 {
-					if c := buf[0]; '0' <= c && c <= '9' {
-						i -= 1
+					isDigits := true
+					for _, c := range buf {
+						if c < '0' || c > '9' {
+							isDigits = false
+							break
+						}
+					}
+					if isDigits {
+						i -= len(buf)
 						got = argNo
 					}
 				}

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -490,6 +490,36 @@ func TestHaveRedirect(t *testing.T) {
 	}
 }
 
+func TestHaveRedirectPrefix(t *testing.T) {
+	parser := NewParser()
+
+	line := "cmd 2x> file"
+	args, err := parser.Parse(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"cmd", "2x"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+	if rest := line[parser.Position:]; rest != "> file" {
+		t.Fatalf("Expected %q, but %q:", "> file", rest)
+	}
+
+	line = "cmd 10> file"
+	args, err = parser.Parse(line)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected = []string{"cmd"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+	if rest := line[parser.Position:]; rest != "10> file" {
+		t.Fatalf("Expected %q, but %q:", "10> file", rest)
+	}
+}
+
 func TestBackquoteInFlag(t *testing.T) {
 	parser := NewParser()
 	parser.ParseBacktick = true


### PR DESCRIPTION
The redirect check before `>` only looked at the first byte of the pending token, so a word like `2x` was dropped as if it were a file descriptor number. It also rewound Position by a single character, losing digits of multi-digit descriptors (`10>` resumed at `0>`). Treat the token as a descriptor only when it is all digits and rewind by its full length.