### PR TITLE
Honor escaped $ when ParseEnv is enabled

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -144,6 +144,13 @@ loop:
 				got = argSingle
 				continue
 			}
+			if p.ParseEnv && r == '$' {
+				// Keep the backslash so replaceEnv treats the '$' as
+				// literal instead of expanding it.
+				buf += `\$`
+				got = argSingle
+				continue
+			}
 			if r == 't' {
 				r = '\t'
 			}
@@ -254,7 +261,7 @@ loop:
 
 		case '(':
 			if !singleQuoted && !doubleQuoted && !backQuote {
-				if !dollarQuote && strings.HasSuffix(buf, "$") {
+				if !dollarQuote && strings.HasSuffix(buf, "$") && !strings.HasSuffix(buf, `\$`) {
 					dollarQuote = true
 					buf += "("
 					continue

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -361,6 +361,20 @@ func TestEnvBareDollar(t *testing.T) {
 	}
 }
 
+func TestEnvEscapedDollar(t *testing.T) {
+	parser := NewParser()
+	parser.ParseEnv = true
+	parser.Getenv = func(k string) string { return map[string]string{"FOO": "bar"}[k] }
+	args, err := parser.Parse(`echo \$FOO "\$FOO" $FOO`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "$FOO", "$FOO", "bar"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
 func TestNoEnv(t *testing.T) {
 	parser := NewParser()
 	parser.ParseEnv = true


### PR DESCRIPTION
`\$FOO` was expanded even though the dollar sign was escaped, because the parser stripped the backslash before replaceEnv ran. Keep the backslash in the token when ParseEnv is enabled so replaceEnv emits a literal `$`, and do not open a $(...) substitution after an escaped dollar.