### PR TITLE
Recognize env assignments whose value contains '='

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -363,7 +363,18 @@ func (p *Parser) ParseWithEnvs(line string) (envs []string, args []string, err e
 }
 
 func isEnv(arg string) bool {
-	return len(strings.Split(arg, "=")) == 2
+	i := strings.IndexByte(arg, '=')
+	if i <= 0 {
+		return false
+	}
+	for j := 0; j < i; j++ {
+		c := arg[j]
+		if c == '_' || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || (j > 0 && '0' <= c && c <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func Parse(line string) ([]string, error) {

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -596,6 +596,21 @@ func TestParseWithEnvs(t *testing.T) {
 			wantEnvs: []string{},
 			wantArgs: []string{"cmd", "--args=A=B", "-A=B"},
 		},
+		{
+			line:     "FOO=a=b cmd",
+			wantEnvs: []string{"FOO=a=b"},
+			wantArgs: []string{"cmd"},
+		},
+		{
+			line:     "LS_COLORS=di=34:ln=35 ls",
+			wantEnvs: []string{"LS_COLORS=di=34:ln=35"},
+			wantArgs: []string{"ls"},
+		},
+		{
+			line:     "=x 1a=b cmd",
+			wantEnvs: []string{},
+			wantArgs: []string{"=x", "1a=b", "cmd"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.line, func(t *testing.T) {


### PR DESCRIPTION
isEnv required exactly one `=`, so valid assignments like `LS_COLORS=di=34:ln=35` were classified as command arguments, while tokens with an empty or invalid name like `=x` were treated as assignments. Check that the part before the first `=` is a valid identifier instead.