### PR TITLE
Fix comment handling inside backticks and drop empty substitution words

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -138,7 +138,7 @@ func (p *Parser) isExcluded(r rune) bool {
 	return false
 }
 
-// SetExcludeSeparators indictes the parser to ignore provided separators when parsing
+// SetExcludeSeparators indicates the parser to ignore provided separators when parsing
 // example: parser.SetExcludeSeparators(';','\t')
 func (p *Parser) SetExcludeSeparators(r ...rune) {
 	p.excludedSep = r
@@ -220,7 +220,7 @@ loop:
 				if backQuote || dollarQuote {
 					backtick += string(r)
 				}
-			} else if got != argNo {
+			} else if got == argQuoted || (got != argNo && buf != "") {
 				if p.ParseEnv {
 					if got == argSingle {
 						parser := &Parser{ParseEnv: false, ParseBacktick: false, Position: 0, Dir: p.Dir}
@@ -350,7 +350,7 @@ loop:
 				break loop
 			}
 		case '#':
-			if p.ParseComment && len(buf) == 0 && !(escaped || singleQuoted || doubleQuoted) {
+			if p.ParseComment && len(buf) == 0 && !(escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote) {
 				comment = true
 				continue loop
 			}
@@ -363,7 +363,7 @@ loop:
 		}
 	}
 
-	if got != argNo {
+	if got == argQuoted || (got != argNo && buf != "") {
 		if p.ParseEnv {
 			if got == argSingle {
 				parser := &Parser{ParseEnv: false, ParseBacktick: false, Position: 0, Dir: p.Dir}

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -80,6 +80,55 @@ func TestComment(t *testing.T) {
 	}
 }
 
+func TestCommentInBacktick(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+	parser := NewParser()
+	parser.ParseComment = true
+	parser.ParseBacktick = true
+	args, err := parser.Parse("echo `# x` done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "done"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
+func TestEmptySubstitution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+	parser := NewParser()
+	parser.ParseBacktick = true
+	args, err := parser.Parse("echo `true` done $(true) \"\"")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"echo", "done", ""}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+}
+
+func TestExcludeSeparators(t *testing.T) {
+	parser := NewParser()
+	parser.SetExcludeSeparators(';', '\t')
+	args, err := parser.Parse("a;b c\td e; \"f;g\"")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"a;b", "c\td", "e;", "f;g"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("Expected %#v, but %#v:", expected, args)
+	}
+	if got := string(parser.ExcludedSeparators()); got != ";\t" {
+		t.Fatalf("Expected %q, but %q:", ";\t", got)
+	}
+}
+
 func TestError(t *testing.T) {
 	_, err := Parse("foo '")
 	if err == nil {


### PR DESCRIPTION
Follow-ups for #58 and #55:

- A `#` immediately after an opening backtick started a comment and left the backtick unclosed (`echo \`# x\` done` failed with ParseComment and ParseBacktick enabled). Leave `#` literal inside `...` / $(...) so the subshell handles it.
- An empty command substitution result produced an empty argument (`echo \`true\` done` returned [echo "" done]); drop empty unquoted words like the shell does. Explicit "" is kept.
- Add tests for SetExcludeSeparators, which landed without any.
- Fix a doc comment typo (indictes -> indicates).