### PR TITLE
fix: allow parentheses inside tokens

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -300,18 +300,19 @@ loop:
 					continue
 				}
 
-				// Backtick parsing disabled:
-				// A bare ')' is a syntax error, consistent with '(' handling.
-				// Only close an already-open $(...) region.
-				if !dollarQuote {
+				// Backtick parsing disabled: close an open $(...) region.
+				if dollarQuote {
+					buf = append(buf, ')')
+					backtick = backtick[:0]
+					dollarQuote = false
+					got = argSingle
+					continue
+				}
+				// A bare ')' that starts a token is still a syntax error.
+				// Mid-token ')' is allowed so CLI flags like foo(1,2) parse.
+				if len(buf) == 0 {
 					return nil, errInvalidCmdLine
 				}
-
-				buf = append(buf, ')')
-				backtick = backtick[:0]
-				dollarQuote = false
-				got = argSingle
-				continue
 			}
 
 		case '(':
@@ -320,7 +321,9 @@ loop:
 					dollarQuote = true
 					buf = append(buf, '(')
 					continue
-				} else {
+				}
+				// '(' that starts a token is a syntax error; mid-token is literal.
+				if len(buf) == 0 {
 					return nil, errInvalidCmdLine
 				}
 			}

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -752,3 +752,31 @@ func TestSubShellEnv(t *testing.T) {
 		}
 	})
 }
+
+func TestLiteralParens(t *testing.T) {
+	// Mid-token parentheses appear in real CLI flags (issue #54).
+	args, err := Parse(`cmd --x=foo(1,2)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(args, []string{"cmd", "--x=foo(1,2)"}) {
+		t.Fatalf("got %#v", args)
+	}
+
+	args, err = Parse(`--providers.docker.constraints=Label('a.label.name','foo')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{`--providers.docker.constraints=Label(a.label.name,foo)`}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("got %#v want %#v", args, want)
+	}
+
+	// Token-leading parentheses remain invalid.
+	if _, err := Parse(`echo (hello)`); err == nil {
+		t.Fatal("expected error for token-leading '('")
+	}
+	if _, err := Parse(`)a`); err == nil {
+		t.Fatal("expected error for token-leading ')'")
+	}
+}


### PR DESCRIPTION
## Summary
Unquoted parentheses mid-token (e.g. `--x=foo(1,2)`, Traefik `Label('a','b')`) failed with `invalid command line string` (see #54).

Allow `(` / `)` inside a token. A parenthesis that *starts* a token is still a syntax error, and `ParseBacktick=true` still rejects unmatched `)` for the existing security cases.

## Test plan
- [x] `go test ./...`
- [x] New cases for mid-token parens + token-leading still rejected