### PR TITLE
Don't treat quoted digits as a redirect descriptor

### DIFF
--- a/shellwords.go
+++ b/shellwords.go
@@ -159,6 +159,8 @@ func (p *Parser) Parse(line string) ([]string, error) {
 
 	pos := -1
 	got := argNo
+	// Whether the pending token contains any quoted or escaped character.
+	tokenQuoted := false
 
 	flush := func() error {
 		if got == argQuoted || (got != argNo && len(buf) > 0) {
@@ -180,6 +182,7 @@ func (p *Parser) Parse(line string) ([]string, error) {
 		}
 		buf = buf[:0]
 		got = argNo
+		tokenQuoted = false
 		return nil
 	}
 
@@ -191,12 +194,14 @@ loop:
 		if comment {
 			if r == '\n' {
 				comment = false
+				tokenQuoted = false
 			}
 			continue
 		}
 
 		if escaped {
 			escaped = false
+			tokenQuoted = true
 			if backQuote || dollarQuote {
 				buf = append(buf, '\\')
 				buf = append(buf, string(r)...)
@@ -331,6 +336,7 @@ loop:
 					got = argQuoted
 				}
 				doubleQuoted = !doubleQuoted
+				tokenQuoted = true
 				continue
 			}
 
@@ -340,12 +346,15 @@ loop:
 					got = argQuoted
 				}
 				singleQuoted = !singleQuoted
+				tokenQuoted = true
 				continue
 			}
 
 		case ';', '&', '|', '<', '>':
 			if !(escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote) {
-				if r == '>' && len(buf) > 0 {
+				// A file descriptor number is only a redirect prefix while it
+				// is unquoted; quoting makes it an ordinary argument.
+				if r == '>' && len(buf) > 0 && !tokenQuoted {
 					isDigits := true
 					for _, c := range buf {
 						if c < '0' || c > '9' {

--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -609,6 +609,72 @@ func TestHaveRedirectPrefix(t *testing.T) {
 	}
 }
 
+func TestHaveQuotedRedirectPrefix(t *testing.T) {
+	tests := []struct {
+		line         string
+		parseComment bool
+		wantArgs     []string
+		wantRest     string
+	}{
+		{
+			line:     `cmd "10">file`,
+			wantArgs: []string{"cmd", "10"},
+			wantRest: ">file",
+		},
+		{
+			line:     `cmd '10'>file`,
+			wantArgs: []string{"cmd", "10"},
+			wantRest: ">file",
+		},
+		{
+			line:     `cmd 1\0>file`,
+			wantArgs: []string{"cmd", "10"},
+			wantRest: ">file",
+		},
+		{
+			line:     `cmd 2"">file`,
+			wantArgs: []string{"cmd", "2"},
+			wantRest: ">file",
+		},
+		{
+			line:     `cmd ""2>file`,
+			wantArgs: []string{"cmd", "2"},
+			wantRest: ">file",
+		},
+		{
+			// Quoting earlier in the line must not disarm a later descriptor.
+			line:     `cmd "x" 2>file`,
+			wantArgs: []string{"cmd", "x"},
+			wantRest: "2>file",
+		},
+		{
+			// A comment ends the line without flushing, so the quoting before
+			// it must not carry over to the next line's descriptor.
+			line:         "cmd \"\"#comment\n2>file",
+			parseComment: true,
+			wantArgs:     []string{"cmd"},
+			wantRest:     "2>file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			parser := NewParser()
+			parser.ParseComment = tt.parseComment
+			args, err := parser.Parse(tt.line)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("Expected %#v, but %#v", tt.wantArgs, args)
+			}
+			if rest := tt.line[parser.Position:]; rest != tt.wantRest {
+				t.Errorf("Expected %q, but %q", tt.wantRest, rest)
+			}
+		})
+	}
+}
+
 func TestBackquoteInFlag(t *testing.T) {
 	parser := NewParser()
 	parser.ParseBacktick = true


### PR DESCRIPTION
A quoted file descriptor number is still treated as a redirect prefix, so the argument is silently dropped:

```go
p := shellwords.NewParser()
args, _ := p.Parse(`cmd "10">file`)
// args     == []string{"cmd"}   // the "10" argument is gone
// Position == 6, so line[p.Position:] == `0">file`
```

POSIX only recognizes an `IO_NUMBER` when the digits before `>` are unquoted, so `"10"` here is an ordinary word and `>` redirects stdout. `sh`, `bash` and `zsh` agree:

```sh
$ sh -c 'printf "A\n" 2>/tmp/a'    # fd 2 redirect, "A" stays on stdout
A
$ sh -c 'printf "A\n" "2">/tmp/a'  # "2" is an argument, stdout goes to the file
$ cat /tmp/a
A
```

Same for `'10'>`, `1\0>` and `2"">`.

This is the case #66 left open: that fix made the check require the whole token to be digits, but the token's bytes are all it can see, and quoting is invisible there. The symptom is the one #66 describes, an argument dropped and `Position` rewound into the middle of the token, so a caller resuming at `line[Position:]` gets `0">file`.

## The fix

Track whether the pending token contains any quoted or escaped character, and skip the descriptor check when it does. The flag is read in exactly one place, the `'>'` check, so no input that does not reach that branch can change behaviour.

It is also cleared where a comment ends. That is the parser's one token boundary that does not go through `flush`, and without it `echo ""#c\n2>file` with `ParseComment` would lose a legitimate fd 2 redirect. There is a test for that case.

The tests fail without the change. `cmd "x" 2>file` is in there too, pinning that quoting earlier in the line still leaves a later descriptor working.

Not addressed here, but next door: with `ParseBacktick`, digits produced by a substitution reach the same check (`cmd $(printf 2)>file` drops the `2`), and since the rewind is by `len(buf)` it can drive `Position` negative for longer output, which would panic a caller slicing on it. Happy to do that separately if you want it.

---
Used AI assistance on this; I reviewed and tested the change myself.